### PR TITLE
Remove References to a specific Python Version

### DIFF
--- a/tuxemon/views/pages/index.ejs
+++ b/tuxemon/views/pages/index.ejs
@@ -64,7 +64,7 @@
         <div class="col-lg-4">
           <img src="images/python2.5.png" alt="Python Powered" style="width: 140px;">
           <h2>Python Powered</h2>
-          <p>Tuxemon is written with Python 2.7. Python is a cross-platform, interpreted, interactive, object-oriented, extensible programming language provides an extraordinary combination of clarity and versatility.</p>
+          <p>Tuxemon is written with Python. Python is a cross-platform, interpreted, interactive, object-oriented, extensible programming language provides an extraordinary combination of clarity and versatility.</p>
           <p><a class="btn btn-default" href="https://www.python.org/" role="button">View details &raquo;</a></p>
         </div><!-- /.col-lg-4 -->
         <div class="col-lg-4">

--- a/tuxemon/views/pages/index.ejs.bak
+++ b/tuxemon/views/pages/index.ejs.bak
@@ -151,7 +151,7 @@
         <div class="col-lg-4">
           <img src="images/python2.5.png" alt="Python Powered" style="width: 140px;">
           <h2>Python Powered</h2>
-          <p>Tuxemon is written with Python 2.7. Python is a cross-platform, interpreted, interactive, object-oriented, extensible programming language provides an extraordinary combination of clarity and versatility.</p>
+          <p>Tuxemon is written with Python. Python is a cross-platform, interpreted, interactive, object-oriented, extensible programming language provides an extraordinary combination of clarity and versatility.</p>
           <p><a class="btn btn-default" href="https://www.python.org/" role="button">View details &raquo;</a></p>
         </div><!-- /.col-lg-4 -->
         <div class="col-lg-4">

--- a/tuxemon/views/pages/index.html
+++ b/tuxemon/views/pages/index.html
@@ -154,7 +154,7 @@
         <div class="col-lg-4">
           <img src="images/python2.5.png" alt="Python Powered" style="width: 140px;">
           <h2>Python Powered</h2>
-          <p>Tuxemon is written with Python 2.7. Python is a cross-platform, interpreted, interactive, object-oriented, extensible programming language provides an extraordinary combination of clarity and versatility.</p>
+          <p>Tuxemon is written with Python. Python is a cross-platform, interpreted, interactive, object-oriented, extensible programming language provides an extraordinary combination of clarity and versatility.</p>
           <p><a class="btn btn-default" href="https://www.python.org/" role="button">View details &raquo;</a></p>
         </div><!-- /.col-lg-4 -->
         <div class="col-lg-4">

--- a/tuxemon/views/pages/windows-install.ejs
+++ b/tuxemon/views/pages/windows-install.ejs
@@ -30,13 +30,11 @@
 
           <p class="lead"><b><h3>Source</b><h3></p>
           <p class="lead">Use the following steps to run Tuxemon on Windows from source:</p>
-          <p class="lead">1. Download and install Python 2.7 <a href='https://www.python.org/ftp/python/2.7.8/python-2.7.8.msi'>here</a>.</p>
-          <p class="lead">2. Download and install Pygame <a href='http://pygame.org/ftp/pygame-1.9.1.win32-py2.7.msi'>here</a>.</p>
-          <p class="lead">3. Download and install the Python Imaging Library <a href='//effbot.org/downloads/PIL-1.1.7.win32-py2.7.exe'>here</a>.</p>
-          <p class="lead">4. Download "get-pip.py" <a href='https://raw.github.com/pypa/pip/master/contrib/get-pip.py'>here</a> and save it to your Python installation directory (Default: C:\Python27). You may need to go to "File"-> "Save Page" in your browser to save the file.</p>
-          <p class="lead">5. Install pip by opening up a command prompt by going to Start-> Run and typing in "cmd". Then run the following commands:<br><code>C:\Python27\python.exe C:\Python27\get-pip.py<br>C:\Python27\Scripts\pip.exe install pytmx<br>C:\Python27\Scripts\pip.exe install netifaces<br>C:\Python27\Scripts\pip.exe install six<br>C:\Python27\Scripts\pip.exe install neteria</code></p>
-          <p class="lead">6. Download the latest development version of Tuxemon <a href='files/builds/tuxemon-unstable-latest.tgz'>here</a> and extract the archive to a folder.</p>
-          <p class="lead">7. Double-click on "tuxemon.py" to launch Tuxemon.</p>
+          <p class="lead">1. Download and install Python <a href='https://www.python.org/downloads/windows/'>here</a>.</p>
+          <p class="lead">2. Download and install Pygame <a href='https://www.pygame.org/wiki/GettingStarted#Windows%20installation'>here</a>.</p>
+          <p class="lead">3. Download and install the Python Imaging Library <a href='https://pillow.readthedocs.io/en/stable/installation.html#windows-installation'>here</a>.</p>
+          <p class="lead">4. Download the latest development version of Tuxemon <a href='files/builds/tuxemon-unstable-latest.tgz'>here</a> and extract the archive to a folder.</p>
+          <p class="lead">5. Double-click on "tuxemon.py" to launch Tuxemon.</p>
 
         </div>
         <div class="col-md-5">


### PR DESCRIPTION
* Removes references that suggest Tuxemon requires Python 2, or a specific version of Python.
* Updated instructions in the Windows installation Guide
  * No longer links to specific versions, but instead a Windows specific but version agnostic download page.
  * Removes instructions for installing `pip` as this is bundled with Python now.
  * Replaced link for installing Python Image Library as the old link was down.

A brief discussion on the topic can be seen here if you're in the Discord guild for Tuxemon:  
https://discord.com/channels/357631277891059712/357631277891059713/783128889618595911