### PR TITLE
add matrix to community list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,9 @@ build/Release
 # https://www.npmjs.org/doc/misc/npm-faq.html#should-i-check-my-node_modules-folder-into-git
 node_modules
 tuxemon/node_modules
+
+.vscode/
+*.code-workspace
+
+# Local History for Visual Studio Code
+.history/

--- a/tuxemon/views/partials/navbar.ejs
+++ b/tuxemon/views/partials/navbar.ejs
@@ -24,6 +24,7 @@
                     <li><a href="http://forum.tuxemon.org">Forums</a></li>
                     <li><a href="http://www.reddit.com/r/tuxemon">Subreddit</a></li>
                     <li><a href="https://discord.gg/3ZffZwz">Discord</a></li>
+                    <li><a href="https://matrix.to/#/#tuxemon-bridged-discord:matrix.org">Matrix</a></li>
                     <li <% if (page_name === 'irc') { %> class="active"<% } %>><a href="irc.html">IRC</a></li>
                   </ul>
                 </li>
@@ -50,6 +51,3 @@
         </div>
       </div>
     </div>
-
-
-


### PR DESCRIPTION
The Discord community has been bridged with Matrix now, would it be reasonable to add it to the website?

It's noted as unofficial, but it does appear to be endorsed by the Tuxemon team, which does make it notable. At least for users that aren't a big fan of Discord or don't have an account.

On the side, this also ignores Visual Studio Code files via `.gitignore`.
