### PR TITLE
chore: remove matrix from community list

### DIFF
--- a/tuxemon/views/partials/navbar.ejs
+++ b/tuxemon/views/partials/navbar.ejs
@@ -23,7 +23,6 @@
                   <ul class="dropdown-menu" role="menu">
                     <li><a href="http://www.reddit.com/r/tuxemon">Subreddit</a></li>
                     <li><a href="https://discord.gg/3ZffZwz">Discord</a></li>
-                    <li><a href="https://matrix.to/#/#tuxemon-bridged-discord:matrix.org">Matrix</a></li>
                   </ul>
                 </li>
                 <li <% if (page_name === 'download') { %> class="active"<% } %>><a href="download.html">Download</a></li>


### PR DESCRIPTION
On Aug 19 2021, I proposed that Matrix should be added to the community list as it was bridged to the Discord guild.

While I'm in the Matrix space/chat, I'm not an active participant, so let me know if I'm missing something, but the status of this seems to have changed:

* The bridged channel no longer exists. (The link on the website doesn't link to a valid room.)
* The remaining Matrix chat rooms are noted as unofficial.
* The Matrix chat rooms aren't very active. It's a nice space for people that don't have Discord, but not an _alternative_. A prospective contributor that joins the Matrix room thinking it's an alternative may be underwhelmed.

Perhaps it's worth dropping the Matrix link from the website to keep the community more focused on Discord?

## Alternatives

Instead of removing Matrix, the link could instead be replaced with the invite to the space, but if it's unofficial with no relation/bridge to the Discord guild, I didn't think it was worthwhile:

https://matrix.to/#/#tuxemon-space:matrix.org

## References

* Effectively reverts https://github.com/Tuxemon/Tuxemon-Website/pull/10